### PR TITLE
Movable window

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,8 +327,7 @@ impl FileDialog {
       .resizable(self.resizable)
       .collapsible(false);
 
-    if self.anchor != None {
-      let (align, offset) = self.anchor.unwrap();
+    if let Some((align, offset)) = self.anchor {
       window = window.anchor(align, offset);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub struct FileDialog {
   current_pos: Option<Pos2>,
   default_size: Vec2,
   scrollarea_max_height: f32,
-  anchor: (Align2, Vec2),
+  anchor: Option<(Align2, Vec2)>,
   filter: Option<Filter>,
   resizable: bool,
   rename: bool,
@@ -155,7 +155,7 @@ impl FileDialog {
       current_pos: None,
       default_size: vec2(512.0, 512.0),
       scrollarea_max_height: 320.0,
-      anchor: (Align2::CENTER_CENTER, vec2(0.0, 0.0)),
+      anchor: None,
       filter: None,
       resizable: true,
       rename: true,
@@ -168,7 +168,7 @@ impl FileDialog {
 
   /// Set the window anchor.
   pub fn anchor(mut self, align: Align2, offset: impl Into<Vec2>) -> Self {
-    self.anchor = (align, offset.into());
+    self.anchor = Some((align, offset.into()));
     self
   }
 
@@ -321,13 +321,16 @@ impl FileDialog {
   }
 
   fn ui(&mut self, ctx: &Context, is_open: &mut bool) {
-    let (align, offset) = self.anchor;
+    let (align, offset) = self.anchor.unwrap();
     let mut window = Window::new(RichText::new(self.title()).strong())
       .open(is_open)
       .default_size(self.default_size)
-      .anchor(align, offset)
       .resizable(self.resizable)
       .collapsible(false);
+
+    if self.anchor != None {
+      window = window.anchor(align, offset);
+    }
 
     if let Some(current_pos) = self.current_pos {
       window = window.current_pos(current_pos);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,7 +321,6 @@ impl FileDialog {
   }
 
   fn ui(&mut self, ctx: &Context, is_open: &mut bool) {
-    let (align, offset) = self.anchor.unwrap();
     let mut window = Window::new(RichText::new(self.title()).strong())
       .open(is_open)
       .default_size(self.default_size)
@@ -329,6 +328,7 @@ impl FileDialog {
       .collapsible(false);
 
     if self.anchor != None {
+      let (align, offset) = self.anchor.unwrap();
       window = window.anchor(align, offset);
     }
 


### PR DESCRIPTION
This makes it so the window is not aligned by default, allowing it to be moved around.