### PR TITLE
Allow to set a default filename in the edit field

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,11 @@ impl FileDialog {
     }
   }
 
+  pub fn default_filename(mut self, filename: impl Into<String>) -> Self {
+    self.filename_edit = filename.into();
+    self
+  }
+
   /// Set the window anchor.
   pub fn anchor(mut self, align: Align2, offset: impl Into<Vec2>) -> Self {
     self.anchor = Some((align, offset.into()));


### PR DESCRIPTION
Hello, I'm working on one of my pet projects that needs a file dialog. Everything is works great so far, but I needed to have the ability to set a default filename to save (using current timestamp in the filename for example), so made this small change that is harmless (by utilizing the existing builder pattern) and will not harm any existing codebases. Hope that this will be helpful for other people as well. :)