### PR TITLE
update egui dependency to version 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ repository = "https://github.com/Barugon/egui_file"
 version = "0.10.2"
 
 [dependencies.egui]
-version = "0.22"
+version = "0.23"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Taken from the [Dotrix](https://github.com/lowenware/dotrix) project, made into 
 ````toml
 [dependencies]
 egui_file = "0.10"
-eframe = "0.22"
+eframe = "0.23"
 ````
 
 ````rust


### PR DESCRIPTION
Just had to update the dep (and readme reference) and everything compiled fine.
Didn't bumped the version nnumber though, I'll leave it to the repo maintainer.
Thanks !