### PR TITLE
New `directory()` method for obtaining the current path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,6 +279,11 @@ impl FileDialog {
     self.selected_file.as_ref().map(|info| info.path.as_path())
   }
 
+  /// Currently mounted directory that is being shown in the dialog box
+  pub fn directory(&self) -> &Path {
+    self.path.as_path()
+  }
+
   /// Set the dialog's current opened path
   pub fn set_path(&mut self, path: impl Into<PathBuf>) {
     self.path = path.into();


### PR DESCRIPTION
Simple change that exposes the currently selected path of the dialog.

This is specifically so that [#148](https://github.com/rewin123/space_editor/issues/148#issue-2061810200) can function through this usage.