### PR TITLE
Fix compile error with multi_select

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -822,6 +822,7 @@ impl FileDialog {
             infos.push(FileInfo {
               path: drive,
               dir: true,
+              selected: false,
             });
           }
           infos.append(&mut file_infos);


### PR DESCRIPTION
This fixes this compile error:

```
error[E0063]: missing field `selected` in initializer of `FileInfo`
   --> C:\Users\Matthew Lim\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui_file-0.16.1\src\lib.rs:822:24
    |
822 |             infos.push(FileInfo {
    |                        ^^^^^^^^ missing `selected`
```

(Fixes #41)
