### PR TITLE
Implements an option to keep the file dialog above all other windows.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ pub struct FileDialog {
   new_folder: bool,
   multi_select_enabled: bool,
   range_start: Option<usize>,
+  keep_on_top: bool,
 
   /// Show drive letters on Windows.
   #[cfg(windows)]
@@ -99,8 +100,8 @@ impl Debug for FileDialog {
       .field("rename", &self.rename)
       .field("new_folder", &self.new_folder)
       .field("multi_select", &self.multi_select_enabled)
-      .field("range_start", &self.range_start);
-
+      .field("range_start", &self.range_start)
+      .field("keep_on_top", &self.keep_on_top);
     // Closures don't implement std::fmt::Debug.
     // .field("shown_files_filter", &self.shown_files_filter)
     // .field("filename_filter", &self.filename_filter)
@@ -179,6 +180,7 @@ impl FileDialog {
       show_hidden: false,
       multi_select_enabled: false,
       range_start: None,
+      keep_on_top: false,
     }
   }
 
@@ -267,6 +269,11 @@ impl FileDialog {
   pub fn filename_filter(mut self, filter: Filter<String>) -> Self {
     self.filename_filter = filter;
     self
+  }
+
+  pub fn keep_on_top(mut self, keep_on_top: bool) -> Self {
+      self.keep_on_top = keep_on_top;
+      self
   }
 
   /// Get the dialog type.
@@ -462,7 +469,12 @@ impl FileDialog {
       window = window.current_pos(current_pos);
     }
 
-    window.show(ctx, |ui| self.ui_in_window(ui));
+    window.show(ctx, |ui| {
+      if self.keep_on_top {
+          ui.ctx().move_to_top(ui.layer_id());
+      }
+      self.ui_in_window(ui)
+    });
   }
 
   fn ui_in_window(&mut self, ui: &mut Ui) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,8 +272,8 @@ impl FileDialog {
   }
 
   pub fn keep_on_top(mut self, keep_on_top: bool) -> Self {
-      self.keep_on_top = keep_on_top;
-      self
+    self.keep_on_top = keep_on_top;
+    self
   }
 
   /// Get the dialog type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -471,7 +471,7 @@ impl FileDialog {
 
     window.show(ctx, |ui| {
       if self.keep_on_top {
-          ui.ctx().move_to_top(ui.layer_id());
+        ui.ctx().move_to_top(ui.layer_id());
       }
       self.ui_in_window(ui)
     });


### PR DESCRIPTION
Added a simple flag to keep the FileDialog on top.
