### PR TITLE
Fix default change when you select a directory in save file mode. 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,7 +360,9 @@ impl FileDialog {
 
   fn select(&mut self, file: Option<FileInfo>) {
     if let Some(info) = &file {
-      self.filename_edit = get_file_name(info).to_owned();
+      if self.dialog_type != DialogType::SaveFile {
+        self.filename_edit = get_file_name(info).to_owned();
+      }
     }
     self.selected_file = file;
   }


### PR DESCRIPTION
In save file mode, you can provide a default file name but it is replaced by the selected directory when navigating in the hierarchy.
This patch keeps the file name while changing the directory.